### PR TITLE
Add Python for Everyone

### DIFF
--- a/communities.yaml
+++ b/communities.yaml
@@ -156,3 +156,8 @@
   lat: 33.748997
   lng: -84.387985
   url: https://www.meetup.com/python-atlanta/
+
+- name: Python for Everyone
+  lat: 33.027852
+  lng: -96.7115229
+  url: https://www.meetup.com/python4e/


### PR DESCRIPTION
Add Dallas, TX-based group Python for Everyone.