### PR TITLE
Added entry for GruPy-ABC

### DIFF
--- a/communities.yaml
+++ b/communities.yaml
@@ -44,6 +44,11 @@
   lng: -46.633308
   url: https://www.meetup.com/pt-BR/Grupy-SP/
 
+- name: GruPy-ABC
+  lat: -23.684167
+  lng: -46.506865
+  url: http://grupyabc.org/
+
 - name: py013
   lat: -23.956290
   lng: -46.326460


### PR DESCRIPTION
[City of Grande ABC], SP, Brazil: [Latitude]; [Longitude]

Santo André, SP, Brazil: 23° 39' 50" S 46° 32' 16" O
São Bernardo do Campo, SP, Brazil: 23° 41' 38" S 46° 33' 54" O
São Caetano do Sul, SP, Brazil: 23° 37' 23" S 46° 33' 04" O
Diadema, SP, Brazil: 23° 41' 09" S 46° 37' 22" O
Mauá, SP, Brazil: 23° 40' 04" S 46° 27' 39" O
Ribeirão Pires, SP, Brazil: 23° 42' 39" S 46° 24' 46" O
Rio Grande da Serra, SP, Brazil: 23° 44' 38" S 46° 23' 52" O

Arithmetic mean of positions: 23° 40.57142857142857' 28.714285714285715" S 46° 29.857142857142858' 33.285714285714285" O

Around
  lat: -23.684167
  lng: -46.506865